### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -11,6 +11,9 @@ on: [push, workflow_dispatch]
 jobs:
   repolint:
     name: Run Repolinter
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Test Default Branch


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-unity-agent/security/code-scanning/1](https://github.com/newrelic/newrelic-unity-agent/security/code-scanning/1)

To fix the problem, we should explicitly add a `permissions` block to the Repolinter job (`jobs.repolint`) in the `.github/workflows/repolinter.yml` file. This block will restrict the job’s access to the least privilege required. Specifically, since Repolinter’s `output_type: issue` creates issues, it needs `issues: write`. Actions that read repo metadata (via `github-script`) require `contents: read`. Therefore, within `jobs.repolint`, we should add:

```yaml
permissions:
  contents: read
  issues: write
```

This should be inserted immediately after `name: Run Repolinter` (before `runs-on:`). No package dependencies or additional code logic are needed beyond the YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
